### PR TITLE
Cleaun-up and maintanance

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,5 +41,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: ${{ steps.version.outputs.Version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+examples/autobahn/k6
+examples/autobahn/reports

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+GOLANGCI_LINT_VERSION = $(shell head -n 1 .golangci.yml | tr -d '\# ')
+TMPDIR ?= /tmp
+
+test:
+	go test -race -timeout 800s ./...
+
+ci-like-lint:
+	@docker run --rm -t -v $(shell pwd):/app \
+		-v $(TMPDIR)/golangci-cache-$(GOLANGCI_LINT_VERSION):/golangci-cache \
+		--env "GOLANGCI_LINT_CACHE=/golangci-cache" \
+		-w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) \
+		make lint
+
+lint:
+	golangci-lint run --out-format=tab ./...
+
+check: ci-like-lint test
+
+.PHONY: test lint ci-like-lint check

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/mstoykov/k6-taskqueue-lib v0.1.0
 	github.com/stretchr/testify v1.8.0
-	go.k6.io/k6 v0.40.1-0.20221017105932-3c97ec7d1231
+	go.k6.io/k6 v0.41.0
 	gopkg.in/guregu/null.v3 v3.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/xk6-redis v0.1.1/go.mod h1:z7el1Tz8advY+ex419KfLbENzSQYgaA2lQYwMlt9yMM=
 github.com/grafana/xk6-timers v0.1.2/go.mod h1:XHmDIXAKe30NJMXrxKIKMFXx98etsCl0jBYktjsSURc=
+github.com/grafana/xk6-websockets v0.1.5/go.mod h1:+vlArhLMFFvNFgs5GUsw3RtzlDxli1G5SFMdC/QEUxU=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -183,8 +184,9 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.k6.io/k6 v0.37.1-0.20220426072701-d105f5474bc3/go.mod h1:1bTdDsXTT2V3in3ZgdR15MDW6SQQh5nWni59tirqNB8=
 go.k6.io/k6 v0.38.2/go.mod h1:1bTdDsXTT2V3in3ZgdR15MDW6SQQh5nWni59tirqNB8=
-go.k6.io/k6 v0.40.1-0.20221017105932-3c97ec7d1231 h1:5hQKdn7qkkM2P7JZmZ+WpXo6urnMcILpmVuGi0NGeHo=
 go.k6.io/k6 v0.40.1-0.20221017105932-3c97ec7d1231/go.mod h1:vaSQ1A2rnC+wrKRJ4ExZCT6kKLfAEYoaIY9UR0uAjjk=
+go.k6.io/k6 v0.41.0 h1:w/J10BV3MGahDF3UsT3WESNBCpsw7soxj9GaLCGTf4I=
+go.k6.io/k6 v0.41.0/go.mod h1:ZrgrR06UZbzZt9u+so/yQhlkJFH5gkJ3qCp1hwq1mEU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/websockets/events/events.go
+++ b/websockets/events/events.go
@@ -1,0 +1,14 @@
+// Package events represent the events that can be sent to the client
+// https://dom.spec.whatwg.org/#event
+package events
+
+const (
+	// OPEN is the event name for the open event
+	OPEN = "open"
+	// CLOSE is the event name for the close event
+	CLOSE = "close"
+	// MESSAGE is the event name for the message event
+	MESSAGE = "message"
+	// ERROR is the event name for the error event
+	ERROR = "error"
+)

--- a/websockets/helpers.go
+++ b/websockets/helpers.go
@@ -1,0 +1,13 @@
+package websockets
+
+import (
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/common"
+)
+
+// must is a small helper that will panic if err is not nil.
+func must(rt *goja.Runtime, err error) {
+	if err != nil {
+		common.Throw(rt, err)
+	}
+}

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/gorilla/websocket"
+	"github.com/grafana/xk6-websockets/websockets/events"
 	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
@@ -85,22 +86,13 @@ type webSocket struct {
 }
 
 func (r *WebSocketsAPI) websocket(c goja.ConstructorCall) *goja.Object {
-	urlValue := c.Argument(0)
 	rt := r.vu.Runtime()
-	if urlValue == nil || goja.IsUndefined(urlValue) {
-		common.Throw(rt, errors.New("WebSocket requires a url"))
-	}
-	urlString := urlValue.String()
-	url, err := url.Parse(urlString)
+
+	url, err := parseURL(c)
 	if err != nil {
-		common.Throw(rt, fmt.Errorf("WebSocket requires valid url, but got %q which resulted in %w", urlString, err))
+		common.Throw(rt, err)
 	}
-	if url.Scheme != "ws" && url.Scheme != "wss" {
-		common.Throw(rt, fmt.Errorf("WebSocket requires url with scheme ws or wss, but got %q", url.Scheme))
-	}
-	if url.Fragment != "" {
-		common.Throw(rt, fmt.Errorf("WebSocket requires no url fragment, but got %q", url.Fragment))
-	}
+
 	// TODO implement protocols
 	registerCallback := func() func(func() error) {
 		// fmt.Println("RegisterCallback called")
@@ -124,39 +116,60 @@ func (r *WebSocketsAPI) websocket(c goja.ConstructorCall) *goja.Object {
 	}
 
 	// Maybe have this after the goroutine below ?!?
+	defineWebsocket(rt, w)
 
-	must := func(err error) {
-		if err != nil {
-			common.Throw(rt, err)
-		}
+	go w.establishConnection()
+	return w.obj
+}
+
+// parseURL parses the url from the constructor call or returns an error
+func parseURL(c goja.ConstructorCall) (*url.URL, error) {
+	urlValue := c.Argument(0)
+
+	if urlValue == nil || goja.IsUndefined(urlValue) {
+		return nil, errors.New("WebSocket requires a url")
 	}
-	must(w.obj.DefineDataProperty(
+	urlString := urlValue.String()
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, fmt.Errorf("WebSocket requires valid url, but got %q which resulted in %w", urlString, err)
+	}
+	if url.Scheme != "ws" && url.Scheme != "wss" {
+		return nil, fmt.Errorf("WebSocket requires url with scheme ws or wss, but got %q", url.Scheme)
+	}
+	if url.Fragment != "" {
+		return nil, fmt.Errorf("WebSocket requires no url fragment, but got %q", url.Fragment)
+	}
+
+	return url, nil
+}
+
+// defineWebsocket defines all properties and methods for the WebSocket
+func defineWebsocket(rt *goja.Runtime, w *webSocket) {
+	must(rt, w.obj.DefineDataProperty(
 		"addEventListener", rt.ToValue(w.addEventListener), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
 	// TODO add onmessage,onclose and so on.
-	must(w.obj.DefineDataProperty(
+	must(rt, w.obj.DefineDataProperty(
 		"send", rt.ToValue(w.send), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
-	must(w.obj.DefineDataProperty(
+	must(rt, w.obj.DefineDataProperty(
 		"close", rt.ToValue(w.close), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
-	must(w.obj.DefineDataProperty(
-		"url", rt.ToValue(urlString), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
-	must(w.obj.DefineAccessorProperty( // this needs to be with an accessor as we change the value
+	must(rt, w.obj.DefineDataProperty(
+		"url", rt.ToValue(w.url.String()), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
+	must(rt, w.obj.DefineAccessorProperty( // this needs to be with an accessor as we change the value
 		"readyState", rt.ToValue(func() ReadyState {
 			return w.readyState
 		}), nil, goja.FLAG_FALSE, goja.FLAG_TRUE))
-	must(w.obj.DefineDataProperty(
+	must(rt, w.obj.DefineDataProperty(
 		"bufferedAmount", rt.ToValue(w.bufferedAmount), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
 	// extensions
 	// protocol
-	must(w.obj.DefineAccessorProperty(
+	must(rt, w.obj.DefineAccessorProperty(
 		"binaryType", rt.ToValue(func() goja.Value {
 			return rt.ToValue("ArrayBuffer")
 		}), rt.ToValue(func() goja.Value {
 			common.Throw(rt, errors.New("binaryType is not settable in k6 as it doesn't support Blob"))
 			return nil // it never gets to here
 		}), goja.FLAG_FALSE, goja.FLAG_TRUE))
-
-	go w.establishConnection()
-	return w.obj
 }
 
 type message struct {
@@ -446,20 +459,22 @@ func (w *webSocket) loop() {
 				})
 
 				rt := w.vu.Runtime()
-				ev := w.newEvent("message", msg.t)
-				must := func(err error) {
-					if err != nil {
-						common.Throw(rt, err)
-					}
-				}
+				ev := w.newEvent(events.MESSAGE, msg.t)
+
 				if msg.mtype == websocket.BinaryMessage {
 					// TODO this technically could be BLOB , but we don't support that
 					ab := rt.NewArrayBuffer(msg.data)
-					must(ev.DefineDataProperty("data", rt.ToValue(ab), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
+					must(rt, ev.DefineDataProperty("data", rt.ToValue(ab), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
 				} else {
-					must(ev.DefineDataProperty("data", rt.ToValue(string(msg.data)), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
+					must(
+						rt,
+						ev.DefineDataProperty("data", rt.ToValue(string(msg.data)), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE),
+					)
 				}
-				must(ev.DefineDataProperty("origin", rt.ToValue(w.url.String()), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
+				must(
+					rt,
+					ev.DefineDataProperty("origin", rt.ToValue(w.url.String()), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE),
+				)
 
 				// fmt.Println("messagelisteners", len(w.messageListeners))
 				for _, messageListener := range w.messageListeners {
@@ -587,18 +602,15 @@ func (w *webSocket) connectionClosedWithError(err error) error {
 
 // newEvent return an event implementing "implements" https://dom.spec.whatwg.org/#event
 // needs to be called on the event loop
+// TODO: move to events
 func (w *webSocket) newEvent(eventType string, t time.Time) *goja.Object {
 	rt := w.vu.Runtime()
 	o := rt.NewObject()
-	must := func(err error) {
-		if err != nil {
-			common.Throw(rt, err)
-		}
-	}
-	must(o.DefineAccessorProperty("type", rt.ToValue(func() string {
+
+	must(rt, o.DefineAccessorProperty("type", rt.ToValue(func() string {
 		return eventType
 	}), nil, goja.FLAG_FALSE, goja.FLAG_TRUE))
-	must(o.DefineAccessorProperty("target", rt.ToValue(func() interface{} {
+	must(rt, o.DefineAccessorProperty("target", rt.ToValue(func() interface{} {
 		return w.obj
 	}), nil, goja.FLAG_FALSE, goja.FLAG_TRUE))
 	// skip srcElement
@@ -609,7 +621,7 @@ func (w *webSocket) newEvent(eventType string, t time.Time) *goja.Object {
 	// skip stopImmediatePropagation
 	// skip a bunch more
 
-	must(o.DefineAccessorProperty("timestamp", rt.ToValue(func() float64 {
+	must(rt, o.DefineAccessorProperty("timestamp", rt.ToValue(func() float64 {
 		return float64(t.UnixNano()) / 1_000_000 // milliseconds as double as per the spec
 		// https://w3c.github.io/hr-time/#dom-domhighrestimestamp
 	}), nil, goja.FLAG_FALSE, goja.FLAG_TRUE))
@@ -619,7 +631,7 @@ func (w *webSocket) newEvent(eventType string, t time.Time) *goja.Object {
 
 func (w *webSocket) callOpenListeners(timestamp time.Time) error {
 	for _, openListener := range w.openListeners {
-		if _, err := openListener(w.newEvent("open", timestamp)); err != nil {
+		if _, err := openListener(w.newEvent(events.OPEN, timestamp)); err != nil {
 			_ = w.conn.Close()                   // TODO log it?
 			_ = w.connectionClosedWithError(err) // TODO log it?
 			return err
@@ -630,13 +642,9 @@ func (w *webSocket) callOpenListeners(timestamp time.Time) error {
 
 func (w *webSocket) callErrorListeners(e error) error { // TODO use the error even thought it is not by the spec
 	rt := w.vu.Runtime()
-	must := func(err error) {
-		if err != nil {
-			common.Throw(rt, err)
-		}
-	}
-	ev := w.newEvent("error", time.Now())
-	must(ev.DefineDataProperty("error",
+
+	ev := w.newEvent(events.ERROR, time.Now())
+	must(rt, ev.DefineDataProperty("error",
 		rt.ToValue(e),
 		goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
 	for _, errorListener := range w.errorListeners {
@@ -650,7 +658,7 @@ func (w *webSocket) callErrorListeners(e error) error { // TODO use the error ev
 func (w *webSocket) callCloseListeners() error {
 	for _, closeListener := range w.closeListeners {
 		// TODO the event here needs to be different and have an error
-		if _, err := closeListener(w.newEvent("close", time.Now())); err != nil { // TODO fix timestamp
+		if _, err := closeListener(w.newEvent(events.CLOSE, time.Now())); err != nil { // TODO fix timestamp
 			return err
 		}
 	}
@@ -661,14 +669,13 @@ func (w *webSocket) addEventListener(event string, listener func(goja.Value) (go
 	// TODO support options https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#parameters
 	// TODO implement `onerror` and co as well
 	switch event {
-	case "open":
+	case events.OPEN:
 		w.openListeners = append(w.openListeners, listener)
-	case "error":
+	case events.ERROR:
 		w.errorListeners = append(w.errorListeners, listener)
-	case "message":
-		// fmt.Println("!!!!!!!!!!!!! message added!!!!!!")
+	case events.MESSAGE:
 		w.messageListeners = append(w.messageListeners, listener)
-	case "close":
+	case events.CLOSE:
 		w.closeListeners = append(w.closeListeners, listener)
 	default:
 		w.vu.State().Logger.Warnf("Unknown event for websocket %s", event)


### PR DESCRIPTION
# What?

A small PR that does minor clean-up:
* Introduces the constraints of the events
* Move `must` to a helper to reduce the number of initialization and lambda usages
* "service" things like `Makefile`, `.gitignore`

# Why?

This helps to maintain the changes easier and reduce the size of the following PRs