### PR TITLE
Update k6 and add tests around races

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/mstoykov/k6-taskqueue-lib v0.1.0
 	github.com/stretchr/testify v1.8.2
-	go.k6.io/k6 v0.43.2-0.20230309162744-333a3d1ed383
+	go.k6.io/k6 v0.43.2-0.20230404142020-8d6f222a7511
 	go.uber.org/goleak v1.2.1
 	gopkg.in/guregu/null.v3 v3.3.0
 )
@@ -33,7 +33,6 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.18.1 // indirect
-	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,6 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
-github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
-github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
@@ -109,7 +107,6 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -125,8 +122,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.k6.io/k6 v0.43.2-0.20230309162744-333a3d1ed383 h1:BEdgGkW+Zlc3LLN4Kt5yWxFMOTUk36h9TZ0EXlsF/U0=
-go.k6.io/k6 v0.43.2-0.20230309162744-333a3d1ed383/go.mod h1:mfI7coHBbXfw8jmYZdjonog1znyxUTtHGMT2Pv+GU3o=
+go.k6.io/k6 v0.43.2-0.20230404142020-8d6f222a7511 h1:DfOWpLsk0iI+LPOa7+Dtj3QIWlWvp5UX+zUTWpv/q2c=
+go.k6.io/k6 v0.43.2-0.20230404142020-8d6f222a7511/go.mod h1:Azozhj76R5Fa1pPatdrTgl7+cL5JHBTIqp4aWroBMw4=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/dop251/goja"
@@ -104,10 +105,8 @@ func (r *WebSocketsAPI) websocket(c goja.ConstructorCall) *goja.Object {
 
 	// TODO implement protocols
 	registerCallback := func() func(func() error) {
-		// fmt.Println("RegisterCallback called")
 		callback := r.vu.RegisterCallback()
 		return func(f func() error) {
-			// fmt.Println("callback called")
 			callback(f)
 			// fmt.Println("callback ended")
 		}
@@ -336,6 +335,7 @@ func (w *webSocket) loop() {
 	// readErrChan := make(chan error)
 	samplesOutput := w.vu.State().Samples
 	ctx := w.vu.Context()
+	wg := new(sync.WaitGroup)
 
 	defer func() {
 		now := time.Now()
@@ -350,33 +350,14 @@ func (w *webSocket) loop() {
 			Metadata: w.tagsAndMeta.Metadata,
 			Value:    duration,
 		})
-		ch := make(chan struct{})
-		w.tq.Queue(func() error {
-			defer close(ch)
-			return w.connectionClosedWithError(nil)
-		})
-		select {
-		case <-ch:
-		case <-ctx.Done():
-			// unfortunately it is really possible that k6 has been winding down the VU and the above code
-			// to close the connection will just never be called as the event loop no longer executes the callbacks.
-			// This ultimately needs a separate signal for when the eventloop will not execute anything after this.
-			// To try to prevent leaking goroutines here we will try to figure out if we need to close the `done`
-			// channel and wait a bit and close it if it isn't. This might be better off with more mutexes
-			timer := time.NewTimer(time.Millisecond * 250)
-			select {
-			case <-w.done:
-				// everything is fine
-			case <-timer.C:
-				close(w.done) // hopefully this means we won't double close
-			}
-			timer.Stop()
-		}
 		_ = w.conn.Close()
+		wg.Wait()
 		w.tq.Close()
 	}()
+	wg.Add(1)
 	// Wraps a couple of channels around conn.ReadMessage
 	go func() { // copied from k6/ws
+		defer wg.Done()
 		for {
 			messageType, data, err := w.conn.ReadMessage()
 			if err != nil {
@@ -402,9 +383,13 @@ func (w *webSocket) loop() {
 		}
 	}()
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
+		wg.Add(1)
 		writeChannel := make(chan message)
 		go func() {
+			defer wg.Done()
 			for {
 				select {
 				case msg, ok := <-writeChannel:
@@ -464,14 +449,9 @@ func (w *webSocket) loop() {
 				}
 				select {
 				case msg = <-w.writeQueueCh:
-					select {
-					case writeChannel <- msg:
-					default:
-						queue = append(queue, msg)
-					}
+					queue = append(queue, msg)
 				case wch <- msg:
 					queue = queue[:copy(queue, queue[1:])]
-
 				case <-w.done:
 					return
 				}
@@ -481,6 +461,15 @@ func (w *webSocket) loop() {
 	ctxDone := ctx.Done()
 	for {
 		select {
+		case <-ctxDone:
+			// VU is shutting down during an interrupt
+			// socket events will not be forwarded to the VU
+			w.queueClose()
+			ctxDone = nil // this is to block this branch and get through w.done
+			// fmt.Println("ctxDone")
+		case <-w.done:
+			// fmt.Println("w.done")
+			return
 		case pingData := <-pingChan:
 
 			// Handle pings received from the server
@@ -503,15 +492,6 @@ func (w *webSocket) loop() {
 
 				return w.callEventListeners(events.PONG)
 			})
-
-		case <-ctxDone:
-			// VU is shutting down during an interrupt
-			// socket events will not be forwarded to the VU
-			w.queueClose()
-			ctxDone = nil // this is to block this branch and get through w.done
-
-		case <-w.done:
-			return
 		}
 	}
 }

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -323,7 +323,7 @@ func (w *webSocket) emitConnectionMetrics(ctx context.Context, start time.Time, 
 
 const writeWait = 10 * time.Second
 
-//nolint:funlen,gocognit,cyclop
+//nolint:funlen,gocognit
 func (w *webSocket) loop() {
 	// Pass ping/pong events through the main control loop
 	pingChan := make(chan string)

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -466,9 +466,7 @@ func (w *webSocket) loop() {
 			// socket events will not be forwarded to the VU
 			w.queueClose()
 			ctxDone = nil // this is to block this branch and get through w.done
-			// fmt.Println("ctxDone")
 		case <-w.done:
-			// fmt.Println("w.done")
 			return
 		case pingData := <-pingChan:
 


### PR DESCRIPTION
Before the update of k6 it was possible that a websocket connection will start stopping due to context Done. That will use the eventloop to synchronise the update of the statuses and the closing of the done channel.

And everything will work *except* if the eventloop was not already stopping due to unhandled exception (for example).

In that case the eventloop will just not run the call to stop the connection.

Detecting that is inherently hard and will require to then have a separate mechanism to close and stop the websocket connection that is only used in this particular case.

The test provided also caught leakage of goroutines which is now caught and fixed.

fixes #36