### PR TITLE
feat: allow name tag, and overwrite url tag with name tag if set

### DIFF
--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -269,11 +269,12 @@ func (w *webSocket) establishConnection(params *wsParams) {
 	w.conn = conn
 
 	nameTagValue, nameTagManuallySet := params.tagsAndMeta.Tags.Get(metrics.TagName.String())
+	// After k6 v0.41.0, the `name` and `url` tags have the exact same values:
 	if nameTagManuallySet {
 		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagURL, nameTagValue)
-		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagName, nameTagValue)
 	} else {
 		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagURL, w.url.String())
+		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagName, w.url.String())
 	}
 
 	w.emitConnectionMetrics(ctx, start, connectionDuration)

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -268,7 +268,13 @@ func (w *webSocket) establishConnection(params *wsParams) {
 	}
 	w.conn = conn
 
-	w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagURL, w.url.String())
+	nameTagValue, nameTagManuallySet := params.tagsAndMeta.Tags.Get(metrics.TagName.String())
+	if nameTagManuallySet {
+		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagURL, nameTagValue)
+		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagName, nameTagValue)
+	} else {
+		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagURL, w.url.String())
+	}
 
 	w.emitConnectionMetrics(ctx, start, connectionDuration)
 	if connErr != nil {


### PR DESCRIPTION
## What?

This PR allows users to manually set name tag. Also, when name tag is present, it will overwrite the url tag.
## Why?

Query parameters in the url, cause too many trends to appear in metrics. This is explained in the issue as well.
## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Spiritual equivelant in k6 repo: https://github.com/grafana/k6/pull/2703

<!-- Does it close an issue? -->

Closes #33 

<!-- Thanks for your contribution! 🙏🏼 -->
