### PR TITLE
Warn on not setting binarytype

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dop251/goja v0.0.0-20230919151941-fc55792775de
 	github.com/gorilla/websocket v1.5.0
 	github.com/mstoykov/k6-taskqueue-lib v0.1.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.k6.io/k6 v0.47.1-0.20231012091148-de19a6a1bc53
 	go.uber.org/goleak v1.2.1
@@ -37,7 +38,6 @@ require (
 	github.com/onsi/gomega v1.20.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/tidwall/gjson v1.17.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -178,12 +178,12 @@ func defineWebsocket(rt *goja.Runtime, w *webSocket) {
 		}), rt.ToValue(func(s string) error {
 			switch s {
 			case blobBinaryType:
-				return errors.New("blob is currently not supported, only arraybuffer is.")
+				return errors.New("blob is currently not supported, only arraybuffer is")
 			case arraybufferBinaryType:
 				w.binaryType = s
 				return nil
 			default:
-				return fmt.Errorf("unknown binaryType %s, the supported one is arraybuffer.", s)
+				return fmt.Errorf("unknown binaryType %s, the supported one is arraybuffer", s)
 			}
 		}), goja.FLAG_FALSE, goja.FLAG_TRUE))
 

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -147,6 +147,11 @@ func parseURL(urlValue goja.Value) (*url.URL, error) {
 	return url, nil
 }
 
+const (
+	arraybufferBinaryType = "arraybuffer"
+	blobBinaryType        = "blob"
+)
+
 // defineWebsocket defines all properties and methods for the WebSocket
 func defineWebsocket(rt *goja.Runtime, w *webSocket) {
 	must(rt, w.obj.DefineDataProperty(
@@ -172,9 +177,9 @@ func defineWebsocket(rt *goja.Runtime, w *webSocket) {
 			return rt.ToValue(w.binaryType)
 		}), rt.ToValue(func(s string) error {
 			switch s {
-			case "blob":
-				return fmt.Errorf("blob is currently not supported, only arraybuffer is.")
-			case "arraybuffer":
+			case blobBinaryType:
+				return errors.New("blob is currently not supported, only arraybuffer is.")
+			case arraybufferBinaryType:
 				w.binaryType = s
 				return nil
 			default:
@@ -414,7 +419,7 @@ func (w *webSocket) queueMessage(msg *message) {
 
 		if msg.mtype == websocket.BinaryMessage {
 			if w.binaryType == "" {
-				w.binaryType = "arraybuffer"
+				w.binaryType = arraybufferBinaryType
 				w.vu.State().Logger.Warn(binarytypeWarning)
 			}
 			// TODO this technically could be BLOB , but we don't support that

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -83,6 +83,7 @@ type webSocket struct {
 	// fields that should be seen by js only be updated on the event loop
 	readyState     ReadyState
 	bufferedAmount int
+	binaryType     string
 }
 
 type ping struct {
@@ -168,10 +169,17 @@ func defineWebsocket(rt *goja.Runtime, w *webSocket) {
 	// protocol
 	must(rt, w.obj.DefineAccessorProperty(
 		"binaryType", rt.ToValue(func() goja.Value {
-			return rt.ToValue("ArrayBuffer")
-		}), rt.ToValue(func() goja.Value {
-			common.Throw(rt, errors.New("binaryType is not settable in k6 as it doesn't support Blob"))
-			return nil // it never gets to here
+			return rt.ToValue(w.binaryType)
+		}), rt.ToValue(func(s string) error {
+			switch s {
+			case "blob":
+				return fmt.Errorf("blob is currently not supported, only arraybuffer is.")
+			case "arraybuffer":
+				w.binaryType = s
+				return nil
+			default:
+				return fmt.Errorf("unknown binaryType %s, the supported one is arraybuffer.", s)
+			}
 		}), goja.FLAG_FALSE, goja.FLAG_TRUE))
 
 	setOn := func(property string, el *eventListener) {
@@ -382,6 +390,9 @@ func (w *webSocket) loop() {
 	}
 }
 
+const binarytypeWarning = `You have not set a Websocket binaryType to "arraybuffer", but you got a binary response. ` +
+	`This has been done automatically now, but in the future this will not work.`
+
 func (w *webSocket) queueMessage(msg *message) {
 	w.tq.Queue(func() error {
 		if w.readyState != OPEN {
@@ -402,6 +413,10 @@ func (w *webSocket) queueMessage(msg *message) {
 		ev := w.newEvent(events.MESSAGE, msg.t)
 
 		if msg.mtype == websocket.BinaryMessage {
+			if w.binaryType == "" {
+				w.binaryType = "arraybuffer"
+				w.vu.State().Logger.Warn(binarytypeWarning)
+			}
 			// TODO this technically could be BLOB , but we don't support that
 			ab := rt.NewArrayBuffer(msg.data)
 			must(rt, ev.DefineDataProperty("data", rt.ToValue(ab), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))


### PR DESCRIPTION
## What?

Warn users if they get binary messages but they have not set binarytype

## Why?

As #35 will break this - let's first require users to set it for now.

If we never do #35 we can still make this an error and in the future add Blob support.

This will let us move this out of experimental as the API will be stable once we require a user to set it to arraybuffer

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
