### PR TITLE
Error out on not setting binarytype to arraybuffer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/dop251/goja v0.0.0-20230919151941-fc55792775de
 	github.com/gorilla/websocket v1.5.0
 	github.com/mstoykov/k6-taskqueue-lib v0.1.0
-	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.k6.io/k6 v0.47.1-0.20231012091148-de19a6a1bc53
 	go.uber.org/goleak v1.2.1
@@ -38,6 +37,7 @@ require (
 	github.com/onsi/gomega v1.20.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/tidwall/gjson v1.17.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -395,8 +395,9 @@ func (w *webSocket) loop() {
 	}
 }
 
-const binarytypeWarning = `You have not set a Websocket binaryType to "arraybuffer", but you got a binary response. ` +
-	`This has been done automatically now, but in the future this will not work.`
+const binarytypeError = `websocket's binaryType hasn't been set to "arraybuffer", ` +
+	`but a binary message has been received. ` +
+	`"blob" is still not supported so the websocket is erroring out`
 
 func (w *webSocket) queueMessage(msg *message) {
 	w.tq.Queue(func() error {
@@ -419,8 +420,7 @@ func (w *webSocket) queueMessage(msg *message) {
 
 		if msg.mtype == websocket.BinaryMessage {
 			if w.binaryType == "" {
-				w.binaryType = arraybufferBinaryType
-				w.vu.State().Logger.Warn(binarytypeWarning)
+				return errors.New(binarytypeError)
 			}
 			// TODO this technically could be BLOB , but we don't support that
 			ab := rt.NewArrayBuffer(msg.data)

--- a/websockets/websockets_test.go
+++ b/websockets/websockets_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -19,7 +18,6 @@ import (
 	httpModule "go.k6.io/k6/js/modules/k6/http"
 	"go.k6.io/k6/js/modulestest"
 	"go.k6.io/k6/lib"
-	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/lib/testutils/httpmultibin"
 	"go.k6.io/k6/metrics"
 )
@@ -266,8 +264,6 @@ func TestReadyState(t *testing.T) {
 func TestBinaryState(t *testing.T) {
 	t.Parallel()
 	ts := newTestState(t)
-	logger, hook := testutils.NewLoggerWithHook(t, logrus.WarnLevel)
-	ts.runtime.VU.StateField.Logger = logger
 	_, err := ts.runtime.RunOnEventLoop(ts.tb.Replacer.Replace(`
 		var ws = new WebSocket("WSBIN_URL/ws-echo-invalid")
 		ws.addEventListener("open", () => {
@@ -293,10 +289,7 @@ func TestBinaryState(t *testing.T) {
 			throw new Error("Expects ws.binaryType to not be writable")
 		}
 	`))
-	require.NoError(t, err)
-	logs := hook.Drain()
-	require.Len(t, logs, 1)
-	require.Contains(t, logs[0].Message, binarytypeWarning)
+	require.ErrorContains(t, err, binarytypeError)
 }
 
 func TestExceptionDontPanic(t *testing.T) {


### PR DESCRIPTION
## What?

Error out if binarytype was not set to arraybuffer.

## Why?

This lets us stabalize this in k6 without finishign #35 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
