### PR TITLE
Fix bufferedAmount not updating

### DIFF
--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -190,8 +190,9 @@ func defineWebsocket(rt *goja.Runtime, w *webSocket) {
 		"readyState", rt.ToValue(func() ReadyState {
 			return w.readyState
 		}), nil, goja.FLAG_FALSE, goja.FLAG_TRUE))
-	must(rt, w.obj.DefineDataProperty(
-		"bufferedAmount", rt.ToValue(w.bufferedAmount), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
+	must(rt, w.obj.DefineAccessorProperty(
+		"bufferedAmount", rt.ToValue(func() goja.Value { return rt.ToValue(w.bufferedAmount) }), nil,
+		goja.FLAG_FALSE, goja.FLAG_TRUE))
 	// extensions
 	must(rt, w.obj.DefineAccessorProperty(
 		"protocol", rt.ToValue(func() goja.Value { return rt.ToValue(w.protocol) }), nil, goja.FLAG_FALSE, goja.FLAG_TRUE))

--- a/websockets/websockets_test.go
+++ b/websockets/websockets_test.go
@@ -272,8 +272,17 @@ func TestBinaryState(t *testing.T) {
 		var ws = new WebSocket("WSBIN_URL/ws-echo-invalid")
 		ws.addEventListener("open", () => {
 			ws.send(new Uint8Array([164,41]).buffer)
+			if (ws.bufferedAmount != 2) {
+				throw "Expected 2 bufferedAmount got "+ ws.bufferedAmount
+			}
 			ws.send("k6")
+			if (ws.bufferedAmount != 4) {
+				throw "Expected 4 bufferedAmount got "+ ws.bufferedAmount
+			}
 			ws.onmessage = (e) => {
+				if (ws.bufferedAmount != 0) {
+					throw "Expected 0 bufferedAmount got "+ ws.bufferedAmount
+				}
 				ws.close()
 				call(JSON.stringify(e))
 			}

--- a/websockets/websockets_test.go
+++ b/websockets/websockets_test.go
@@ -280,8 +280,8 @@ func TestBinaryState(t *testing.T) {
 				throw "Expected 4 bufferedAmount got "+ ws.bufferedAmount
 			}
 			ws.onmessage = (e) => {
-				if (ws.bufferedAmount != 0) {
-					throw "Expected 0 bufferedAmount got "+ ws.bufferedAmount
+				if (ws.bufferedAmount != 0 && ws.bufferedAmount != 2) { // it is possible one or both were flushed
+					throw "Expected 0 or 2 bufferedAmount, but got "+ ws.bufferedAmount
 				}
 				ws.close()
 				call(JSON.stringify(e))


### PR DESCRIPTION
## What?

Fix bufferedAmount being observable from js.

## Why?
This is actually how it was supposed to work all along, but the code just exported the value at the time of creating the WebSocket.

It now also includes a test.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Based on #68 