### PR TITLE
Add extensions support to WebSocket

### DIFF
--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -85,6 +85,7 @@ type webSocket struct {
 	bufferedAmount int
 	binaryType     string
 	protocol       string
+	extensions     []string
 }
 
 type ping struct {
@@ -193,7 +194,8 @@ func defineWebsocket(rt *goja.Runtime, w *webSocket) {
 	must(rt, w.obj.DefineAccessorProperty(
 		"bufferedAmount", rt.ToValue(func() goja.Value { return rt.ToValue(w.bufferedAmount) }), nil,
 		goja.FLAG_FALSE, goja.FLAG_TRUE))
-	// extensions
+	must(rt, w.obj.DefineAccessorProperty("extensions",
+		rt.ToValue(func() goja.Value { return rt.ToValue(w.extensions) }), nil, goja.FLAG_FALSE, goja.FLAG_TRUE))
 	must(rt, w.obj.DefineAccessorProperty(
 		"protocol", rt.ToValue(func() goja.Value { return rt.ToValue(w.protocol) }), nil, goja.FLAG_FALSE, goja.FLAG_TRUE))
 	must(rt, w.obj.DefineAccessorProperty(
@@ -304,6 +306,7 @@ func (w *webSocket) establishConnection(params *wsParams) {
 		if conn != nil {
 			w.protocol = conn.Subprotocol()
 		}
+		w.extensions = httpResponse.Header.Values("Sec-WebSocket-Extensions")
 		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagSubproto, w.protocol)
 	}
 	w.conn = conn

--- a/websockets/websockets_test.go
+++ b/websockets/websockets_test.go
@@ -1096,6 +1096,11 @@ func TestCompressionSession(t *testing.T) {
 				throw new Error("wrong message received from server: ", event.data)
 			}
 
+			const expectedExtension = "permessage-deflate; server_no_context_takeover; client_no_context_takeover"
+			if (!(ws.extensions.includes(expectedExtension))) {
+				throw "expected value '" + expectedExtension + "' missing in " + JSON.stringify(ws.extensions);
+			}
+
 			ws.close()
 		}
 


### PR DESCRIPTION
## What?

Implement the extensions property for WebSocket.

## Why?

I was working around this area for #68 and noticed it as well and decided "why not finish implementing all the properties"

So with this all the properties of WebSocket have been implemented. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Based on #68 and #69 