### PR TITLE
Fix passing undefined/null handler

### DIFF
--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -784,10 +784,15 @@ func (w *webSocket) callEventListeners(eventType string) error {
 	return nil
 }
 
-func (w *webSocket) addEventListener(event string, listener func(sobek.Value) (sobek.Value, error)) {
+func (w *webSocket) addEventListener(event string, handler func(sobek.Value) (sobek.Value, error)) {
 	// TODO support options https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#parameters
-	if err := w.eventListeners.add(event, listener); err != nil {
-		w.vu.State().Logger.Warnf("can't add event listener: %s", err)
+
+	if handler == nil {
+		common.Throw(w.vu.Runtime(), fmt.Errorf("handler for event type %q isn't a callable function", event))
+	}
+
+	if err := w.eventListeners.add(event, handler); err != nil {
+		w.vu.State().Logger.Warnf("can't add event handler: %s", err)
 	}
 }
 

--- a/websockets/websockets_test.go
+++ b/websockets/websockets_test.go
@@ -218,6 +218,20 @@ func TestBasic(t *testing.T) {
 	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-echo"), http.StatusSwitchingProtocols, "")
 }
 
+func TestAddUndefinedHandler(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+	sr := ts.tb.Replacer.Replace
+	_, err := ts.runtime.RunOnEventLoop(sr(`
+		var ws = new WebSocket("WSBIN_URL/ws-echo")
+		ws.addEventListener("open", () => {
+			ws.close()
+		})
+		ws.addEventListener("open", undefined)
+	`))
+	require.ErrorContains(t, err, "handler for event type \"open\" isn't a callable function")
+}
+
 func TestBasicWithOn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

Fixes passing undefined/null handler to the `addEventListener`

## Why?

We should not panic.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
