### PR TITLE
Make certain readyState is actually a number when returned

### DIFF
--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -187,8 +187,8 @@ func defineWebsocket(rt *sobek.Runtime, w *webSocket) {
 	must(rt, w.obj.DefineDataProperty(
 		"url", rt.ToValue(w.url.String()), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
 	must(rt, w.obj.DefineAccessorProperty( // this needs to be with an accessor as we change the value
-		"readyState", rt.ToValue(func() ReadyState {
-			return w.readyState
+		"readyState", rt.ToValue(func() sobek.Value {
+			return rt.ToValue((uint)(w.readyState))
 		}), nil, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
 	must(rt, w.obj.DefineAccessorProperty(
 		"bufferedAmount", rt.ToValue(func() sobek.Value { return rt.ToValue(w.bufferedAmount) }), nil,

--- a/websockets/websockets_test.go
+++ b/websockets/websockets_test.go
@@ -1527,3 +1527,26 @@ func testArrayBufferViewSupport(t *testing.T, viewName string) {
 	logs := hook.Drain()
 	require.Len(t, logs, 0)
 }
+
+func TestReadyStateSwitch(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+	logger, hook := testutils.NewLoggerWithHook(t, logrus.WarnLevel)
+	ts.runtime.VU.StateField.Logger = logger
+	_, err := ts.runtime.RunOnEventLoop(ts.tb.Replacer.Replace(`
+		var ws = new WebSocket("WSBIN_URL/ws-echo")
+		try {
+			switch (ws.readyState) {
+				case 0:
+					break;
+				default:
+					throw "ws.readyState doesn't get correct value in switch"
+			}
+		} finally {
+			ws.close()
+		}
+	`))
+	require.NoError(t, err)
+	logs := hook.Drain()
+	require.Len(t, logs, 0)
+}


### PR DESCRIPTION
## What?

Fix readyState to be an actual Number in js 

## Why?

This is what the specification says.

For some reason - likely a bug in goja/Sobek returning a type that is uint8 under the hood (or int) doesn't actually get to be a number in js.

The current fix casts the ReadyState type to uint8 so that Sobek handles it correctly.

Fixes #79

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)